### PR TITLE
feat (ui profile) : add toast to user profile page using react-toastify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-router-dom": "^6.23.0",
         "react-scripts": "5.0.1",
         "react-slick": "^0.30.3",
+        "react-toastify": "^11.0.5",
         "redux": "^5.0.1",
         "redux-persist": "^6.0.0",
         "slick-carousel": "^1.8.1",
@@ -16514,6 +16515,19 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
     "react-slick": "^0.30.3",
+    "react-toastify": "^11.0.5",
     "redux": "^5.0.1",
     "redux-persist": "^6.0.0",
     "slick-carousel": "^1.8.1",

--- a/src/pages/user/profile.jsx
+++ b/src/pages/user/profile.jsx
@@ -340,7 +340,7 @@ const Profile = () => {
           <div className="flex flex-col items center justify-center w-full">
             <button
               onClick={handleLogout}
-              className="mt-8 py-2 shadow-custom-note font-sans w-full bg-red-warning hover:brightness-110 lg:text-lg text-md text-white font-semibold p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 shadow-custom-note"
+              className="mt-8 py-2 shadow-custom-note font-sans w-full bg-red-warning hover:brightness-110 lg:text-lg text-md text-white font-semibold p-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
             >
               Log Out
             </button>

--- a/src/pages/user/profile.jsx
+++ b/src/pages/user/profile.jsx
@@ -1,21 +1,21 @@
-import { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
 import Cookies from "js-cookie";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
-import { ToastContainer, toast } from 'react-toastify'; //npm install react-toastify
-import 'react-toastify/dist/ReactToastify.css';
-import { Bounce } from 'react-toastify';
+import "react-toastify/dist/ReactToastify.css";
 
+import { setLoading, setLogout } from "../../redux/auth.slicer";
+import {
+  default as customerServices,
+  default as CustomerServices,
+} from "../../services/customer.services";
 
-import { setLogout, setLoading } from "../../redux/auth.slicer";
-import customerServices from "../../services/customer.services";
-import CustomerServices from "../../services/customer.services";
-
-import transformPhoneNumber from "../../utils/phone.number.utils";
+import AuthServices from "../../services/auth.services";
 import handleChange from "../../utils/handle.change.utils";
 import LoadingUtils from "../../utils/loading.utils";
-import AuthServices from "../../services/auth.services";
+import transformPhoneNumber from "../../utils/phone.number.utils";
+import { toastContainer } from "../../utils/toast.utils";
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -77,18 +77,6 @@ const Profile = () => {
     if (accessToken) {
       await CustomerServices.changeProfile(editProfile, accessToken, dispatch, setProfile, setEditProfile, setIsEditing);
       await getProfileUser();
-
-      toast.success("Profil berhasil diperbarui!", {
-        position: "top-right",
-        autoClose: 3000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-        theme: "colored",
-        transition: Bounce,
-      });
     }
   };
 
@@ -98,21 +86,7 @@ const Profile = () => {
 
   return (
     <div className="min-h-screen w-screen flex lg:flex-row flex-col items-center justify-center bg-[#F4F5FF]">
-
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="colored"
-        transition={Bounce}
-      />
-
+      {toastContainer()}
 
       {/* for desktop, hidden in mobile screens */}
       <div className="hidden h-[30%] lg:h-screen bg-[#687eff] md:w-[50%] lg:relative lg:flex justify-end items-end rounded-tr-[40px] rounded-br-[40px]">

--- a/src/pages/user/profile.jsx
+++ b/src/pages/user/profile.jsx
@@ -3,6 +3,11 @@ import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import Cookies from "js-cookie";
 
+import { ToastContainer, toast } from 'react-toastify'; //npm install react-toastify
+import 'react-toastify/dist/ReactToastify.css';
+import { Bounce } from 'react-toastify';
+
+
 import { setLogout, setLoading } from "../../redux/auth.slicer";
 import customerServices from "../../services/customer.services";
 import CustomerServices from "../../services/customer.services";
@@ -72,6 +77,18 @@ const Profile = () => {
     if (accessToken) {
       await CustomerServices.changeProfile(editProfile, accessToken, dispatch, setProfile, setEditProfile, setIsEditing);
       await getProfileUser();
+
+      toast.success("Profil berhasil diperbarui!", {
+        position: "top-right",
+        autoClose: 3000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: "colored",
+        transition: Bounce,
+      });
     }
   };
 
@@ -81,6 +98,22 @@ const Profile = () => {
 
   return (
     <div className="min-h-screen w-screen flex lg:flex-row flex-col items-center justify-center bg-[#F4F5FF]">
+
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="colored"
+        transition={Bounce}
+      />
+
+
       {/* for desktop, hidden in mobile screens */}
       <div className="hidden h-[30%] lg:h-screen bg-[#687eff] md:w-[50%] lg:relative lg:flex justify-end items-end rounded-tr-[40px] rounded-br-[40px]">
         <a href="/">

--- a/src/services/customer.services.js
+++ b/src/services/customer.services.js
@@ -1,6 +1,7 @@
 import axios from "axios";
-import { errorSwal, successSwal } from "../utils/alert.utils";
 import { setProfileData } from "../redux/auth.slicer";
+import { errorSwal, successSwal } from "../utils/alert.utils";
+import { toastError, toastSuccess } from "../utils/toast.utils";
 
 const CustomerServices = {
   getProfile: async (accessToken, dispatch) => {
@@ -35,10 +36,10 @@ const CustomerServices = {
       }));
       setEditProfile({ ...editProfile });
       setIsEditing(false);
-      successSwal("Perubahan profile berhasil.");
+      toastSuccess("Profil berhasil diperbarui.");
       return response.data;
     } catch (error) {
-      errorSwal(error.response?.data?.errors);
+      toastError(error.response?.data?.errors);
     }
   },
   orderLaundry: async (accessToken, formData, setIsLoading, navigate) => {

--- a/src/utils/toast.utils.js
+++ b/src/utils/toast.utils.js
@@ -1,0 +1,48 @@
+import { Bounce, ToastContainer, toast } from "react-toastify";
+const toastSuccess = (message) => {
+  return toast.success(message, {
+    position: "top-right",
+    autoClose: 3000,
+    hideProgressBar: false,
+    closeOnClick: true,
+    pauseOnHover: true,
+    draggable: true,
+    progress: undefined,
+    theme: "colored",
+    transition: Bounce,
+  });
+};
+
+const toastError = (message) => {
+  return toast.error(message, {
+    position: "top-right",
+    autoClose: 3000,
+    hideProgressBar: false,
+    closeOnClick: true,
+    pauseOnHover: true,
+    draggable: true,
+    progress: undefined,
+    theme: "colored",
+    transition: Bounce,
+  });
+};
+
+const toastContainer = () => {
+  return (
+    <ToastContainer
+      position="top-right"
+      autoClose={3000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="colored"
+      transition={Bounce}
+    />
+  );
+};
+
+export { toastContainer, toastError, toastSuccess };


### PR DESCRIPTION
### 📌 Description:
This PR replaces the success modal (which required manual dismissal via "OK" or "X") with a react-toastify toast notification that automatically disappears after a few seconds.

### 🎯 Reason for Change:
To improve user experience and interaction flow by:
- Eliminating unnecessary clicks after a successful profile update
- Avoiding blocked UI states where users must manually close a modal 
- Providing a lighter, less intrusive feedback mechanism that's consistent with modern UX patterns

### 🧪 How to Test:
- Go to the Profile page.
- Click the pencil icon to edit phone number or address.
- Make a valid change and click Save.
- ✅ You should see a green toast saying “Profil berhasil diperbarui!” at the top-right.
- ⏱️ The toast should disappear automatically after 5 seconds without requiring user interaction.

### Note
the modal from previous implementation should be removed (handled by customer.services.js). 
make sure that
- There is no modal blocking the screen.
- You can immediately continue interacting with the page.